### PR TITLE
Better syntax support for string literals

### DIFF
--- a/syntax/cue.vim
+++ b/syntax/cue.vim
@@ -17,8 +17,6 @@ syntax match Number "\<\d\+[.]\d*\([Ee][+-]\?\d\+\)\?\>"
 syntax match Number "\<[.]\d\+\([Ee][+-]\?\d\+\)\?\>"
 
 syn match Type "\$"
-"syn region String start='L\=\'' skip='\\\\\|\\\'' end='\''
-
 
 syn match Keyword "\<[a-zA-Z_][a-z0-9A-Z_"()\\ ]*\s*?\?::\?"
 
@@ -40,9 +38,13 @@ syn match Type "<[^>]*>\||"
 syn match Type "\<\(nulll\|bool\|float\|u\?int\(8\|16\|32\|64\|128\)\?\|string\|number\|bytes\|\.\.\.\|[*]\)\>"
 syn match Keyword "\<_[a-zA-Z0-9_]*"
 
-syn region String start='"""' end='"""'
-syn region String start='L\="' end='"'
-syn region Special start='\\(' end=')'
+" String literals.
+syn region String start=+\z(#*\)\z('\|"\)+ skip="\\\z2" end="\z2\z1"
+" Multiline string literals.
+syn region String start=+\z(#*\)\z('''\|"""\)+ end="\z2\z1"
+" Interpolation
+" TODO: handle modified escape delimeters.
+syn region Special start="\\(" end=")"
 syn match Special "\\\(([^)]\+)\)" contained containedin=String
 
 " builtins


### PR DESCRIPTION
Adds support for:
* Quote-escapes (e.g., `"\""`; implementation taken from the [`:syn-region` docs](https://github.com/vim/vim/blob/c70bdab0b8a8262a3784084aa1e6271fee8452f1/runtime/doc/syntax.txt#L3831))
* Bytestrings (`'foo'` vs `"foo"`)
* Modified escape delimeters (e.g., `#"foo"bar"baz"#`)

Removed support for C-style "literal strings" (`L"foo"`), as they are not part of Cue ([spec](https://github.com/cuelang/cue/blob/ff306b7970/doc/ref/spec.md)).  Also made the pattern delimiters consistent: `""` by default, and `++` if the pattern contains a `"` character (this is the convention used by the `:syntax` docs; see [`:syn-pattern`](https://github.com/vim/vim/blob/c70bdab0b8a8262a3784084aa1e6271fee8452f1/runtime/doc/syntax.txt#L4286)).